### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ cscope:
 	@cscope -Rbkq
 
 start:
-	@qemu-system-x86_64 -m 16M -boot a -fda Image -hda $(HDA_IMG)
+	@qemu-system-i386 -m 16M -boot a -fda Image -hda $(HDA_IMG)
 
 debug:
 	@echo $(OS)


### PR DESCRIPTION
fix the bug of Remote 'g' packet reply is too long when using gdb to debug the linux kernel.